### PR TITLE
await session.dispose() in createSession

### DIFF
--- a/lib/create-session.ts
+++ b/lib/create-session.ts
@@ -21,7 +21,7 @@ export async function createSession<T>(cb: (session: ISession) => PromiseLike<T>
   try {
     return await cb(session);
   } finally {
-    session.dispose();
+    await session.dispose();
   }
 }
 


### PR DESCRIPTION
Cleanup might be skipped since dispose() is asynchronous. `createSessions` awaits for dispose, so `createSession` should probably do that too.