### PR TITLE
Ensure process exists, still cleanup chrome.

### DIFF
--- a/lib/spawn-browser.ts
+++ b/lib/spawn-browser.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, spawn } from "child_process";
+import { ChildProcess } from "child_process";
+import execa from 'execa';
 import * as fs from "fs";
 import * as path from "path";
 import { delay } from "./delay";
@@ -108,8 +109,8 @@ class BrowserProcess implements IBrowserProcess {
   private hasExited: boolean = false;
 
   constructor(executablePath: string, args: string[]) {
-    const process = spawn(executablePath, args);
-    process.on("error", (err) => this.lastError = err);
+    const process = execa(executablePath, args);
+    process.on("error", (err: Error) => this.lastError = err);
     process.on("exit", () => this.hasExited = true);
     this.process = process;
     this.pid = process.pid;

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "@types/rimraf": "^2.0.2",
     "@types/tape": "^4.2.29",
     "@types/ws": "^3.2.0",
+    "execa": "^0.10.0",
     "mktemp": "^0.4.0",
     "rimraf": "^2.5.1",
     "ws": "^3.2.0"
   },
   "devDependencies": {
+    "@types/execa": "^0.9.0",
     "faucet": "0.0.1",
     "tape": "^4.4.0",
     "tslint": "^5.5.0",


### PR DESCRIPTION
This should fix most of the Chrome leaks I've been seeing (due to <ctrl-c> etc).

---

I can't seem to make TS happy re: `execa`, any ideas?

```
lib/spawn-browser.ts(2,8): error TS1192: Module '"/Users/spenner/src/krisselden/chrome-debugging-client/node_modules/@types/execa/index"' has no default export.
```